### PR TITLE
two new callbacks added

### DIFF
--- a/WCL/src/main/java/com/google/devrel/wcl/WearManager.java
+++ b/WCL/src/main/java/com/google/devrel/wcl/WearManager.java
@@ -627,6 +627,9 @@ public class WearManager {
      */
     private void onConnected(Bundle bundle) {
         Utils.LOGD(TAG, "Google Api Connected");
+        for (WearConsumer consumer : mWearConsumers) {
+            consumer.onWearableApiConnected();
+        }
         addCapabilities(mCapabilitiesToBeAdded);
         Wearable.CapabilityApi.getAllCapabilities(mGoogleApiClient,
                 CapabilityApi.FILTER_REACHABLE).setResultCallback(
@@ -644,6 +647,7 @@ public class WearManager {
                                     mCapabilityToNodesMapping.put(capability, info.getNodes());
                                 }
                             }
+                            onConnectedInitialCapabilitiesReceived();
                         } else {
                             Log.e(TAG, "getAllCapabilities(): Failed to get all the capabilities");
                         }
@@ -656,12 +660,10 @@ public class WearManager {
                         if (getConnectedNodesResult.getStatus().isSuccess()) {
                             mConnectedNodes.clear();
                             mConnectedNodes.addAll(getConnectedNodesResult.getNodes());
+                            onConnectedInitialNodesReceived();
                         }
                     }
                 });
-        for (WearConsumer consumer : mWearConsumers) {
-            consumer.onWearableApiConnected();
-        }
     }
 
     /**
@@ -1111,6 +1113,16 @@ public class WearManager {
     }
 
     /**
+     * Clients can register to {@link WearConsumer#onWearableInitialConnectedNodesReceived()}.
+     */
+    void onConnectedInitialNodesReceived() {
+        Utils.LOGD(TAG, "onConnectedInitialNodesReceived");
+        for (WearConsumer consumer : mWearConsumers) {
+            consumer.onWearableInitialConnectedNodesReceived();
+        }
+    }
+
+    /**
      * Clients can register to {@link WearConsumer#onWearableCapabilityChanged(String, Set)}.
      */
     void onCapabilityChanged(CapabilityInfo capabilityInfo) {
@@ -1119,6 +1131,15 @@ public class WearManager {
         mCapabilityToNodesMapping.put(capability, nodes);
         for (WearConsumer consumer : mWearConsumers) {
             consumer.onWearableCapabilityChanged(capability, nodes);
+        }
+    }
+
+    /**
+     * Clients can register to {@link WearConsumer#onWearableInitialConnectedCapabilitiesReceived().
+     */
+    void onConnectedInitialCapabilitiesReceived() {
+        for (WearConsumer consumer : mWearConsumers) {
+            consumer.onWearableInitialConnectedCapabilitiesReceived();
         }
     }
 

--- a/WCL/src/main/java/com/google/devrel/wcl/callbacks/AbstractWearConsumer.java
+++ b/WCL/src/main/java/com/google/devrel/wcl/callbacks/AbstractWearConsumer.java
@@ -42,6 +42,16 @@ import java.util.Set;
 public abstract class AbstractWearConsumer implements WearConsumer {
 
     @Override
+    public void onWearableInitialConnectedCapabilitiesReceived() {
+        //no-op
+    }
+
+    @Override
+    public void onWearableInitialConnectedNodesReceived() {
+        //no-op
+    }
+
+    @Override
     public void onWearableAddCapabilityResult(int statusCode) {
         //no-op
     }

--- a/WCL/src/main/java/com/google/devrel/wcl/callbacks/WearConsumer.java
+++ b/WCL/src/main/java/com/google/devrel/wcl/callbacks/WearConsumer.java
@@ -73,6 +73,11 @@ public interface WearConsumer extends WearFileTransfer.OnWearableChannelOutputSt
     void onWearableCapabilityChanged(String capability, Set<Node> nodes);
 
     /**
+     * Called when initial capabilities are received after google api connection.
+     */
+    void onWearableInitialConnectedCapabilitiesReceived();
+
+    /**
      * Called when the result of {@link WearManager#sendMessage(String, String, byte[])}
      * (or other variants of that call) is available.
      *
@@ -156,6 +161,11 @@ public interface WearConsumer extends WearFileTransfer.OnWearableChannelOutputSt
      * Called when the list of connected nodes changes.
      */
     void onWearableConnectedNodes(List<Node> connectedNodes);
+
+    /**
+     * Called when initial list of connected nodes is received - so that you can send messages to it.
+     */
+    void onWearableInitialConnectedNodesReceived();
 
     /**
      * Called when a connected peer disconnects.


### PR DESCRIPTION
For purposes when you want to send message using MessageApi to wearable node immediately after library initialization I had difficulties to do so, as onWearableApiConnected you still do not have nodes list initially populated. 

Therefore I've introduced two new callbacks 
- onWearableInitialConnectedNodesReceived()
- onWearableInitialConnectedCapabilitiesReceived()

which are called right away after onWearableApiConnected. So now when app is eg. interested to fire up message right away after launch app needs to consume these callbacks. Which means: onWearableInitialConnectedNodesReceived() you are safe to fire up message

I am not sure if this is the right correct solution, but it solves my problem and I hope it will help other users of this awesome library.
